### PR TITLE
debian: create user wazo-acceptance-server upon installation

### DIFF
--- a/debian/wazo-acceptance-server.postinst
+++ b/debian/wazo-acceptance-server.postinst
@@ -6,7 +6,7 @@ case "$1" in
     configure)
         # wazo-auth may not be running
         # wazo-auth-keys may not exist
-        wazo-auth-keys service update || true
+        wazo-auth-keys service update --recreate || true
     ;;
 
     abort-upgrade|abort-remove|abort-deconfigure)


### PR DESCRIPTION
Why:

* "wazo-auth-keys service update" complains that the user
  wazo-acceptance-server does not exist